### PR TITLE
Template pattern for AStar and Dijkstra

### DIFF
--- a/src/main/java/edu/wpi/N/algorithms/AStar.java
+++ b/src/main/java/edu/wpi/N/algorithms/AStar.java
@@ -4,7 +4,7 @@ import edu.wpi.N.entities.DbNode;
 import edu.wpi.N.entities.Path;
 import java.util.*;
 
-public class AStar extends AbsAlgo {
+public class AStar extends AlgoTemplate {
 
   /**
    * Finds the shortest path from Start to Goal node using the A* algorithm

--- a/src/main/java/edu/wpi/N/algorithms/AbsAlgo.java
+++ b/src/main/java/edu/wpi/N/algorithms/AbsAlgo.java
@@ -10,21 +10,6 @@ import org.bridj.util.Pair;
 public abstract class AbsAlgo implements IPathFinder {
 
   /**
-   * Abstract method that is overridden by all pathfinders (template)
-   *
-   * @param mapData: HashMap of the nodes and edges
-   * @param startNode: The start node
-   * @param endNode: The destination node
-   * @param handicap: Boolean saying whether path should be handicap accessible
-   * @return: A path of nodes from the start to the end node
-   */
-  public abstract Path findPath(
-      HashMap<String, LinkedList<DbNode>> mapData,
-      DbNode startNode,
-      DbNode endNode,
-      boolean handicap);
-
-  /**
    * Function calculates Euclidean distance between the next Node and current Node (cost of given
    * node)
    *

--- a/src/main/java/edu/wpi/N/algorithms/AlgoTemplate.java
+++ b/src/main/java/edu/wpi/N/algorithms/AlgoTemplate.java
@@ -1,0 +1,24 @@
+package edu.wpi.N.algorithms;
+
+import edu.wpi.N.entities.DbNode;
+import edu.wpi.N.entities.Path;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+public abstract class AlgoTemplate extends AbsAlgo {
+
+  /**
+   * Abstract method that is overridden by AStar and Dijkstra pathfinders (template)
+   *
+   * @param mapData: HashMap of the nodes and edges
+   * @param startNode: The start node
+   * @param endNode: The destination node
+   * @param handicap: Boolean saying whether path should be handicap accessible
+   * @return: A path of nodes from the start to the end node
+   */
+  public abstract Path findPath(
+      HashMap<String, LinkedList<DbNode>> mapData,
+      DbNode startNode,
+      DbNode endNode,
+      boolean handicap);
+}

--- a/src/main/java/edu/wpi/N/algorithms/Dijkstra.java
+++ b/src/main/java/edu/wpi/N/algorithms/Dijkstra.java
@@ -4,7 +4,7 @@ import edu.wpi.N.entities.DbNode;
 import edu.wpi.N.entities.Path;
 import java.util.*;
 
-public class Dijkstra extends AbsAlgo {
+public class Dijkstra extends AlgoTemplate {
 
   /**
    * Finds the shortest path from Start to Goal node using Dijkstra's algorithm

--- a/src/main/java/edu/wpi/N/views/mapDisplay/MapDisplayController.java
+++ b/src/main/java/edu/wpi/N/views/mapDisplay/MapDisplayController.java
@@ -270,7 +270,8 @@ public class MapDisplayController implements Controller, Initializable {
   public void initQuickAccess(ListView<DbNode> firstLst, String type) throws DBException {
     DbNode first = lst_firstLocation.getSelectionModel().getSelectedItem();
     this.path = singleton.savedAlgo.findQuickAccess(first, type);
-    mapBaseController.drawPath(path, first.getFloor());
+    mapBaseController.setFloor(first.getBuilding(), first.getFloor(), path);
+    disableNonPathFloors();
     setTextDecription();
   }
 


### PR DESCRIPTION
Small change to algorithms. Put AStar and Dijkstra algorithms into the template design pattern by adding an abstract class (AlgoTemplate) which extends AbsAlgo and had AStar and Dijkstra extend AlgoTemplate. BFS and DFS still extend AbsAlgo (no functionality changed).

I also made a small fix to the bathroom quick search. I think it didn't get refactored when mapDisplay was refactored. Just needed to call the right function and disable non-path floors.