### PR TITLE
Fixing Class Not Found issue. New errors when loading the jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
 }
 
 def codeCoverageExcludes = [


### PR DESCRIPTION
include the following in our jar section of our build.gradle
exclude 'META-INF/*.RSA'
    exclude 'META-INF/*.SF'
    exclude 'META-INF/*.DSA'

Class Not Found caused by some of the Google API stuff